### PR TITLE
Add system_timer dependency when using Ruby version < 1.9

### DIFF
--- a/instrumental_agent.gemspec
+++ b/instrumental_agent.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency(%q<rb-fsevent>, [">= 0"])
   end
   if RUBY_VERSION < "1.9"
-    s.add_development_dependency(%q<system_timer>, [">= 0"])
+    s.add_dependency(%q<system_timer>, [">= 0"])
   end
 end


### PR DESCRIPTION
A recent change to the `Instrumental::Agent` (on 613ce911bd2) requires the `system_timer` gem while using a ruby version less than 1.9.  This commit updates the gem spec to reflect that requirement.
