### PR TITLE
Send metrics to logger if agent is disabled

### DIFF
--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -239,10 +239,10 @@ module Instrumental
     end
 
     def send_command(cmd, *args)
+      cmd = "%s %s\n" % [cmd, args.collect { |a| a.to_s }.join(" ")]
       if enabled?
         start_connection_worker if !running?
 
-        cmd = "%s %s\n" % [cmd, args.collect { |a| a.to_s }.join(" ")]
         if @queue.size < MAX_BUFFER
           @queue_full_warning = false
           logger.debug "Queueing: #{cmd.chomp}"
@@ -255,6 +255,8 @@ module Instrumental
           logger.debug "Dropping command, queue full(#{@queue.size}): #{cmd.chomp}"
           nil
         end
+      else
+        logger.debug cmd.strip
       end
     end
 

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -48,6 +48,12 @@ describe Instrumental::Agent, "disabled" do
     wait
     @server.commands.should be_empty
   end
+
+  it "should send metrics to logger" do
+    now = Time.now
+    @agent.logger.should_receive(:debug).with("gauge metric 1 #{now.to_i} 1")
+    @agent.gauge("metric", 1)
+  end
 end
 
 describe Instrumental::Agent, "enabled" do


### PR DESCRIPTION
Send metrics to the agent's logger when the agent is not enabled.

This is really convenient when testing in a local development environment 
