### PR TITLE
Updated start_connection_worker so there's a mutex around background thread starting.

### DIFF
--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -366,6 +366,8 @@ module Instrumental
     end
 
     def start_connection_worker
+      # NOTE: We need a mutex around both `running?` and thread creation,
+      # otherwise we could create two threads.
       @start_worker_mutex.synchronize do
         return if running?
         return unless enabled?


### PR DESCRIPTION
Previously, in rare cases, it could be the case that two threads both checked `running?` and then both threads would create an agent background thread. This would result in two threads sharing a socket and trying to connect. Since SSL isn't threadsafe this could cause a segfault.

- [ ] Investigate test-case: `agent = Instrumental::Agent.new("bf5e8cbe60b436b104046a5023fa1fe0"); 10.times.map { Thread.new {agent.increment("thread_test.branch.1") }}.map(&:join)` causing:

    ```
    [2] pry(main)> E, [2016-06-10T12:45:44.249761 #63262] ERROR -- : Exception occurred: Bad Response "fail\n" to "authenticate bf5e8cbe60b436b104046a5023fa1fe0"
/Users/jqr/code/instrumental/ruby/lib/instrumental/agent.rb:390:in `block in send_with_reply_timeout'
/Users/jqr/code/instrumental/ruby/lib/instrumental/agent.rb:237:in `block in with_timeout'
